### PR TITLE
fix: regex rule for detects the IE octal, hex & unicode entities

### DIFF
--- a/.github/workflows/update-db.yaml
+++ b/.github/workflows/update-db.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Downloading resources
         run: |
           mkdir -p db
-          wget -q "https://raw.githubusercontent.com/enygma/expose/master/src/Expose/filter_rules.json" -O "db/common-web-attacks.json" &
+          wget -q "https://raw.githubusercontent.com/dwisiswant0/cwa-filter-rules/master/filters.json" -O "db/common-web-attacks.json" &
           wget -q "https://raw.githubusercontent.com/mitchellkrogza/nginx-ultimate-bad-bot-blocker/master/_generator_lists/bad-ip-addresses.list" -O "db/bad-ip-addresses.txt" &
           wget -q "https://raw.githubusercontent.com/mitchellkrogza/nginx-ultimate-bad-bot-blocker/master/_generator_lists/bad-referrers.list" -O "db/bad-referrers.txt" &
           wget -q "https://raw.githubusercontent.com/JayBizzle/Crawler-Detect/master/raw/Crawlers.txt" -O "db/bad-crawlers.txt" &

--- a/db/common-web-attacks.json
+++ b/db/common-web-attacks.json
@@ -99,7 +99,7 @@
       },
       {
         "id":"9",
-        "rule":"(?:\\\\u00[a-f0-9]{2})|(?:\\\\x0*[a-f0-9]{2})|(?:\\\\\\d{2,3})",
+        "rule":"(?:\\\\u(?:\\{(?:00)?[a-f0-9]{2}\\}|00[a-f0-9]{2}))|(?:\\\\x0*[a-f0-9]{2})|(?:\\\\\\d{2,3})",
         "description":"Detects the IE octal, hex and unicode entities",
         "tags":{
           "tag":[


### PR DESCRIPTION
This change updates the regular expression rule for identifying unicode escape sequences to correctly match the full range of allowed syntax. The new regex pattern includes matches for `\u00[a-f0-9]{2}`, `\x0*[a-f0-9]{2}`, `\u{00[a-f0-9]{2}}` and \d{2,3}

This change will ensure that the program correctly handles unicode escape sequences with the full range of allowed syntax, including those written as `\u{00[a-f0-9]{2}}` and `\u00[a-f0-9]{2}`.